### PR TITLE
Fix typos in client Dockerfile and make it more idiomatic

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -3,29 +3,25 @@
 # container will base on ubuntu 16.04
 FROM ubuntu:16.04
 
-# update and upgrade node first
-RUN apt update -y 
-RUN apt upgrade -y
-
 # install node packages
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CE7709D068DB5E88
-RUN apt install -y software-properties-common python-software-properties
-RUN add-apt-repository "deb https://repo.sovrin.org/sdk/deb/xenial stable"
-RUN apt update -y
-RUN apt upgrade -y 
-RUN apt install -y indy-cli
+RUN apt-get update \
+  && apt-get install -y software-properties-common python-software-properties apt-transport-https ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
+RUN add-apt-repository "deb https://repo.sovrin.org/sdk/deb xenial stable"
+RUN apt-get update  \
+  && apt-get install -y indy-cli \
+  && rm -rf /var/lib/apt/lists/*
 
 # add accpetance_mechanism
 RUN mkdir /workspace
 WORKDIR /workspace
-COPY accpetance_mechanism ./cliconfig.json
+COPY acceptance_mechanism.json ./cliconfig.json
 RUN indy-cli --config ./cliconfig.json
 
 
 # get genesis files
-RUN curl -O https://raw.githubusercontent.com/sovrin-foundation/sovrin/master/sovrin/pool_transactions_builder_genesis
-RUN curl -O https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_sandbox_genesis
-RUN curl -O https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_live_genesis
-
-
+ADD https://raw.githubusercontent.com/sovrin-foundation/sovrin/master/sovrin/pool_transactions_builder_genesis pool_transactions_builder_genesis
+ADD https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_sandbox_genesis pool_transactions_sandbox_genesis
+ADD https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_live_genesis pool_transactions_live_genesis


### PR DESCRIPTION
Fixes a couple of typos in the client Dockerfile. This one works as is on Fedora 32 with Docker 19.03.8.

This commit also refactors the Dockerfile to incorporate some Dockerfile [best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/).